### PR TITLE
query stat add open delete

### DIFF
--- a/push-openapi-java-demo/src/test/java/com/aliyun/demo/push/StatDemoTest.java
+++ b/push-openapi-java-demo/src/test/java/com/aliyun/demo/push/StatDemoTest.java
@@ -24,8 +24,8 @@ public class StatDemoTest extends BaseTest {
             System.out.printf("RequestId: %s\n" , response.getRequestId());
 
             for (QueryPushStatResponse.PushStat item : response.getPushStats()) {
-                System.out.printf("MessageId: %s , ReceivedCount: %s, SentCount: %s\n",
-                        item.getMessageId(), item.getReceivedCount(), item.getSentCount());
+                System.out.printf("MessageId: %s , ReceivedCount: %s, SentCount: %s, OpenedCount: %s, DeletedCount: %s\n",
+                        item.getMessageId(), item.getReceivedCount(), item.getSentCount(), item.getOpenedCount(), item.getDeletedCount);
             }
         }
 
@@ -52,8 +52,8 @@ public class StatDemoTest extends BaseTest {
             System.out.printf("RequestId: %s\n",response.getRequestId());
 
             for (QueryAppPushStatResponse.AppPushStat stat : response.getAppPushStats()) {
-                System.out.printf("Time: %s, ReceivedCount: %s, SentCount: %s \n",
-                        stat.getTime(), stat.getReceivedCount(), stat.getSentCount());
+                System.out.printf("Time: %s, ReceivedCount: %s, SentCount: %s, OpenedCount: %s, DeletedCount: %s\\\n",
+                        stat.getTime(), stat.getReceivedCount(), stat.getSentCount(), stat.getOpenedCount(), stat.getDeletedCount());
             }
         }
 

--- a/push-openapi-net-demo/QueryAppPushStat.cs
+++ b/push-openapi-net-demo/QueryAppPushStat.cs
@@ -28,8 +28,10 @@ namespace AlibabaCloud
                 foreach (QueryAppPushStatResponse.AppPushStat stat in response.AppPushStats)
                 {
                     Console.WriteLine("MessageIdt:" + stat.Time);
-                    Console.WriteLine("SentCountt:" + stat.SentCount);
+                    Console.WriteLine("SentCount:" + stat.SentCount);
                     Console.WriteLine("ReceivedCount:" + stat.ReceivedCount);
+                    Console.WriteLine("OpenedCount:" + stat.OpenedCount);
+                    Console.WriteLine("DeletedCount:" + stat.DeletedCount);
                 }
                 Console.ReadLine();
             }

--- a/push-openapi-net-demo/QueryPushStat.cs
+++ b/push-openapi-net-demo/QueryPushStat.cs
@@ -23,9 +23,10 @@ namespace AlibabaCloud
                 foreach (QueryPushStatResponse.PushStat stat in response.PushStats)
                 {
                     Console.WriteLine("MessageIdt:" + stat.MessageId);
-                    Console.WriteLine("SentCountt:" + stat.SentCount);
+                    Console.WriteLine("SentCount:" + stat.SentCount);
                     Console.WriteLine("ReceivedCount:" + stat.ReceivedCount);
-                   
+                    Console.WriteLine("OpenedCount:" + stat.OpenedCount);
+                    Console.WriteLine("DeletedCount:" + stat.DeletedCount);
                 }
                 Console.ReadLine();
             }


### PR DESCRIPTION
query stat add open delete